### PR TITLE
Fix initial state having headless Hearthians

### DIFF
--- a/QSB/Animation/Player/HelmetAnimator.cs
+++ b/QSB/Animation/Player/HelmetAnimator.cs
@@ -67,10 +67,8 @@ public class HelmetAnimator : MonoBehaviour
 	    {
 		    _fakeHelmetDitheringAnimator.SetVisible(false);
 			FakeHelmet.gameObject.SetActive(false);
-		    if (!SuitGroup.activeSelf)
-		    {
-			    FakeHead.gameObject.SetActive(false);
-		    }
+			// If the player is currently wearing their suit but has no helmet on, make sure to make the head visible (#655)
+			FakeHead.gameObject.SetActive(SuitGroup.activeSelf);
 		}
     }
 


### PR DESCRIPTION
Closes #655

I tried stress testing other edge cases, but this is the only one I found that yielded headless Hearthians