### PR TITLE
Fix NH quantum objects having no ControllingPlayer if they are near spawn

### DIFF
--- a/QSB/QuantumSync/WorldObjects/QSBQuantumObject.cs
+++ b/QSB/QuantumSync/WorldObjects/QSBQuantumObject.cs
@@ -71,6 +71,15 @@ public abstract class QSBQuantumObject<T> : WorldObject<T>, IQSBQuantumObject
 		if (attachedShapes.All(x => x.enabled && x.gameObject.activeInHierarchy && x.active))
 		{
 			IsEnabled = true;
+			// If the shapes are already enabled then OnShapeActivated won't get triggered until it turns off and on again
+			// Then nobody ends up controlling the object until that happens
+			// This doesn't affect base game because there are no quantum objects at spawn, but can affect NH mods
+			// In this case where the host has spawned in and the object is enabled with no ControllingPlayer, the host should take control
+			if (QSBCore.IsHost)
+			{
+				// first player is the host
+				ControllingPlayer = QSBPlayerManager.PlayerList[0].PlayerId;
+			}
 		}
 		else
 		{
@@ -215,7 +224,7 @@ public abstract class QSBQuantumObject<T> : WorldObject<T>, IQSBQuantumObject
 				{
 					_visibleToProbes.Add(player);
 				}
-				
+
 				AttachedObject._visibleInProbeSnapshot = true;
 				return;
 			}
@@ -261,7 +270,7 @@ public abstract class QSBQuantumObject<T> : WorldObject<T>, IQSBQuantumObject
 		{
 			_visibleToProbes.Remove(player);
 		}
-		
+
 		AttachedObject._visibleInProbeSnapshot = _visibleToProbes.Any();
 	}
 

--- a/QSB/QuantumSync/WorldObjects/QSBSocketedQuantumObject.cs
+++ b/QSB/QuantumSync/WorldObjects/QSBSocketedQuantumObject.cs
@@ -37,10 +37,13 @@ public class QSBSocketedQuantumObject : QSBQuantumObject<SocketedQuantumObject>
 	{
 		base.SendInitialState(to);
 
-		this.SendMessage(new SocketStateChangeMessage(
-			AttachedObject._occupiedSocket.GetWorldObject<QSBQuantumSocket>().ObjectId,
-			AttachedObject.transform.localRotation)
-		{ To = to });
+		if (this.ControllingPlayer != 0 && AttachedObject._occupiedSocket != null)
+		{
+			this.SendMessage(new SocketStateChangeMessage(
+				AttachedObject._occupiedSocket.GetWorldObject<QSBQuantumSocket>().ObjectId,
+				AttachedObject.transform.localRotation)
+			{ To = to });
+		}
 	}
 
 	public void MoveToSocket(uint playerId, int socketId, Quaternion localRotation)

--- a/QSB/QuantumSync/WorldObjects/QSBSocketedQuantumObject.cs
+++ b/QSB/QuantumSync/WorldObjects/QSBSocketedQuantumObject.cs
@@ -1,6 +1,8 @@
 ﻿using Cysharp.Threading.Tasks;
 using OWML.Common;
+using QSB.Messaging;
 using QSB.Player;
+using QSB.QuantumSync.Messages;
 using QSB.Utility;
 using QSB.WorldSync;
 using System;
@@ -35,7 +37,10 @@ public class QSBSocketedQuantumObject : QSBQuantumObject<SocketedQuantumObject>
 	{
 		base.SendInitialState(to);
 
-		// todo SendInitialState
+		this.SendMessage(new SocketStateChangeMessage(
+			AttachedObject._occupiedSocket.GetWorldObject<QSBQuantumSocket>().ObjectId,
+			AttachedObject.transform.localRotation)
+		{ To = to });
 	}
 
 	public void MoveToSocket(uint playerId, int socketId, Quaternion localRotation)

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ See the [QSB Developer Wiki](https://github.com/qsb-dev/quantum-space-buddies/wi
 
 ### Contributers
 
-- [xen](https://github.com/xen-42) - Help with syncing particle/sound effects, fixing lantern item bugs, and syncing addon data.
+- [xen](https://github.com/xen-42) - Help with syncing particle/sound effects, fixing lantern item bugs, syncing addon data, and NH compatibility/bug fixes.
 - [Moonstone](https://github.com/MoonstoneStudios) - Improvements to elevators and lifts.
 - [Chris Yeninas](https://github.com/PhantomGamers) - Help with project files and GitHub workflows.
 - [Locochoco](https://github.com/loco-choco) - Code improvements.


### PR DESCRIPTION
Basically, if a QuantumObject is enabled when the host spawns in, no ControllingPlayer was previously being set (it would wait for the shape to later become enabled which would only happen when the player left and re-entered the sector, or if the quantum object was not sectored, then never).

This PR just ensures that the host gets control in that event.

This never happens in base game because there are no quantum objects at spawn, but can (and does) happen in NH addons

Also implemented initial state sync for socketed quantum objects because why not (tested with and without NH).